### PR TITLE
Some minor changes in unit-tests.sh

### DIFF
--- a/tests/unit-tests/unit-tests.sh
+++ b/tests/unit-tests/unit-tests.sh
@@ -12,7 +12,7 @@ FAILED=""
 # Usage: expectFileToContain "Build date" "No build date pressent in /KTH_NODEJS"
 #
 expectFileToContain() {
-    FILE=$(cat /$1)
+    FILE=$(cat /"$1")
     PATTERN="$2"
     FAILURE_INFO="$3"
     
@@ -41,7 +41,7 @@ expectCommandToContain() {
     CMD="$1"
     PATTERN="$2"
     FAILURE_INFO="$3"
-    OUTPUT=`$CMD`
+    OUTPUT=$($CMD)
     
     if [[ "$OUTPUT" == *"$PATTERN"* ]]; then
         if [ -n "$FAILURE_INFO" ]; then

--- a/tests/unit-tests/unit-tests.sh
+++ b/tests/unit-tests/unit-tests.sh
@@ -17,14 +17,14 @@ expectFileToContain() {
     FAILURE_INFO="$3"
     
     if [[ "$FILE" == *"$PATTERN"* ]]; then
-        if [ ! -z "$FAILURE_INFO" ]; then
+        if [ -n "$FAILURE_INFO" ]; then
             passed "$FAILURE_INFO"
         else 
             passed "/KTH_NODEJS contains $PATTERN"
         fi
  
     else
-        if [ ! -z "$FAILURE_INFO" ]; then
+        if [ -n "$FAILURE_INFO" ]; then
             error "$FAILURE_INFO"
         fi
         info "/KTH_NODEJS does not contain pattern '$PATTERN'."
@@ -44,14 +44,14 @@ expectCommandToContain() {
     OUTPUT=`$CMD`
     
     if [[ "$OUTPUT" == *"$PATTERN"* ]]; then
-        if [ ! -z "$FAILURE_INFO" ]; then
+        if [ -n "$FAILURE_INFO" ]; then
             passed "$FAILURE_INFO"
         else 
             passed "'$CMD' contains '$PATTERN'"
         fi
  
     else
-        if [ ! -z "$FAILURE_INFO" ]; then
+        if [ -n "$FAILURE_INFO" ]; then
             error "$FAILURE_INFO"
         fi
         info "'$CMD' did not contain pattern '$PATTERN'."


### PR DESCRIPTION
`! -z` is a double negative recommended solution is to use `-n` instead
`$1 -> "$1"` is to prevent word globbing
```
OUTPUT=`$CMD` -> OUTPUT=$($CMD) 
```
is to remove legacy usage of backticks